### PR TITLE
Fixed password policy regex issue not accepting special characters

### DIFF
--- a/app/containers/Account.js
+++ b/app/containers/Account.js
@@ -49,7 +49,7 @@ export class Account extends Component {
     // one uppercase letter, and a number
     if (!validator.matches(
       this.props.account.password || '',
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,16}$/)
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d-!$%^&*()_+|~=`{}\[\]:";'<>?,.\/]{8,16}$/)
     ) {
       errors.password = (<span>Your password must be 8 - 16 characters, and include at least<br />
         one lowercase letter, one uppercase letter, and a number<br /><br /></span>);


### PR DESCRIPTION
In case your password had special characters (". ~ ! ? ...) the regex would fail in Account.js file and wouldn't let the login form to work even though you met all the requirements. 
Since EA lets users have these special characters in their passwords it is wise to review and fix the regex which is done in this PR.